### PR TITLE
Fixed MSVC C3872 compiler errors by replacing the Greek alphabet symbols with their corresponding English names

### DIFF
--- a/include/ml_dsa/internals/math/reduction.hpp
+++ b/include/ml_dsa/internals/math/reduction.hpp
@@ -31,9 +31,9 @@ power2round(const ml_dsa_field::zq_t r)
 
 // Given an element of Z_q, this routine computes high and low order bits s.t.
 //
-// `r mod^+ q = r1 * α + r0 | -α/2 < r0 <= α/2`
+// `r mod^+ q = r1 * alpha + r0 | -alpha/2 < r0 <= alpha/2`
 //
-// If r1 = (q - 1)/ α then r1 = 0; r0 = r0 - 1
+// If r1 = (q - 1)/ alpha then r1 = 0; r0 = r0 - 1
 //
 // See algorithm 36 of ML-DSA specification https://doi.org/10.6028/NIST.FIPS.204.
 template<uint32_t alpha>

--- a/include/ml_dsa/internals/poly/bit_packing.hpp
+++ b/include/ml_dsa/internals/poly/bit_packing.hpp
@@ -287,12 +287,12 @@ decode(std::span<const uint8_t, ml_dsa_ntt::N * sbw / 8> arr, std::span<ml_dsa_f
   }
 }
 
-// Given a vector of hint bits ( of dimension k x 1 ), this routine encodes hint bits into (ω + k) -bytes.
+// Given a vector of hint bits ( of dimension k x 1 ), this routine encodes hint bits into (omega + k) -bytes.
 //
 // See algorithm 20 of ML-DSA standard @ https://doi.org/10.6028/NIST.FIPS.204.
-template<size_t k, size_t ω>
+template<size_t k, size_t omega>
 static inline constexpr void
-encode_hint_bits(std::span<const ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h, std::span<uint8_t, ω + k> arr)
+encode_hint_bits(std::span<const ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h, std::span<uint8_t, omega + k> arr)
 {
   std::fill(arr.begin(), arr.end(), 0);
 
@@ -310,20 +310,20 @@ encode_hint_bits(std::span<const ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h, std::
       idx += 1ul * flg;
     }
 
-    arr[ω + i] = idx;
+    arr[omega + i] = idx;
   }
 }
 
 // Given a serialized byte array holding hint bits, this routine unpacks hint bits into a vector ( of dimension k x 1 )
-// of degree-255 polynomials s.t. <= ω many hint bits are set.
+// of degree-255 polynomials s.t. <= omega many hint bits are set.
 //
 // Returns boolean result denoting status of decoding of byte serialized hint bits.
 // For example, say return value is true, it denotes that decoding has failed.
 //
 // See algorithm 21 of ML-DSA standard @ https://doi.org/10.6028/NIST.FIPS.204.
-template<size_t k, size_t ω>
+template<size_t k, size_t omega>
 static inline constexpr bool
-decode_hint_bits(std::span<const uint8_t, ω + k> arr, std::span<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h)
+decode_hint_bits(std::span<const uint8_t, omega + k> arr, std::span<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h)
 {
   std::fill(h.begin(), h.end(), ml_dsa_field::zq_t::zero());
 
@@ -333,13 +333,13 @@ decode_hint_bits(std::span<const uint8_t, ω + k> arr, std::span<ml_dsa_field::z
   for (size_t i = 0; i < k; i++) {
     const size_t off = i * ml_dsa_ntt::N;
 
-    const bool flg0 = arr[ω + i] < idx;
-    const bool flg1 = arr[ω + i] > ω;
+    const bool flg0 = arr[omega + i] < idx;
+    const bool flg1 = arr[omega + i] > omega;
     const bool flg2 = flg0 | flg1;
 
     failed |= flg2;
 
-    const size_t till = arr[ω + i];
+    const size_t till = arr[omega + i];
     for (size_t j = idx; !failed && (j < till); j++) {
       const bool flg0 = j > idx;
       const bool flg1 = flg0 & (arr[j] <= arr[j - flg0 * 1]);
@@ -349,10 +349,10 @@ decode_hint_bits(std::span<const uint8_t, ω + k> arr, std::span<ml_dsa_field::z
       h[off + arr[j]] = ml_dsa_field::zq_t::one();
     }
 
-    idx = arr[ω + i];
+    idx = arr[omega + i];
   }
 
-  for (size_t i = idx; i < ω; i++) {
+  for (size_t i = idx; i < omega; i++) {
     const bool flg = arr[i] != 0;
     failed |= flg;
   }

--- a/include/ml_dsa/internals/poly/ntt.hpp
+++ b/include/ml_dsa/internals/poly/ntt.hpp
@@ -10,8 +10,8 @@ static constexpr size_t LOG2N = 8;
 static constexpr size_t N = 1 << LOG2N;
 
 // First primitive 512 -th root of unity modulo q
-static constexpr ml_dsa_field::zq_t ζ(1753);
-static_assert((ζ ^ 512) == ml_dsa_field::zq_t::one(), "ζ must be 512th root of unity modulo Q");
+static constexpr ml_dsa_field::zq_t zeta(1753);
+static_assert((zeta ^ 512) == ml_dsa_field::zq_t::one(), "zeta must be 512th root of unity modulo Q");
 
 // Multiplicative inverse of N over Z_q
 static constexpr auto INV_N = ml_dsa_field::zq_t(N).inv();
@@ -35,23 +35,23 @@ bit_rev(const size_t v)
   return v_rev;
 }
 
-// Precomputed table of powers of ζ, used during polynomial evaluation.
-static constexpr auto ζ_EXP = []() {
+// Precomputed table of powers of ?, used during polynomial evaluation.
+static constexpr auto zeta_EXP = []() {
   std::array<ml_dsa_field::zq_t, N> res;
 
   for (size_t i = 0; i < N; i++) {
-    res[i] = ζ ^ bit_rev<LOG2N>(i);
+    res[i] = zeta ^ bit_rev<LOG2N>(i);
   }
 
   return res;
 }();
 
-// Precomputed table of negated powers of ζ, used during polynomial interpolation.
-static constexpr auto ζ_NEG_EXP = []() {
+// Precomputed table of negated powers of ?, used during polynomial interpolation.
+static constexpr auto zeta_NEG_EXP = []() {
   std::array<ml_dsa_field::zq_t, N> res;
 
   for (size_t i = 0; i < N; i++) {
-    res[i] = -ζ_EXP[i];
+    res[i] = -zeta_EXP[i];
   }
 
   return res;
@@ -77,14 +77,14 @@ ntt(std::span<ml_dsa_field::zq_t, N> poly)
 
     for (size_t start = 0; start < poly.size(); start += lenx2) {
       const size_t k_now = k_beg + (start >> (l + 1));
-      const ml_dsa_field::zq_t ζ_exp = ζ_EXP[k_now];
+      const ml_dsa_field::zq_t zeta_exp = zeta_EXP[k_now];
 
 #if (not defined __clang__) && (defined __GNUG__)
 #pragma GCC unroll 4
 #pragma GCC ivdep
 #endif
       for (size_t i = start; i < start + len; i++) {
-        auto tmp = ζ_exp * poly[i + len];
+        auto tmp = zeta_exp * poly[i + len];
 
         poly[i + len] = poly[i] - tmp;
         poly[i] += tmp;
@@ -114,7 +114,7 @@ intt(std::span<ml_dsa_field::zq_t, N> poly)
 
     for (size_t start = 0; start < poly.size(); start += lenx2) {
       const size_t k_now = k_beg - (start >> (l + 1));
-      const ml_dsa_field::zq_t neg_ζ_exp = ζ_NEG_EXP[k_now];
+      const ml_dsa_field::zq_t neg_zeta_exp = zeta_NEG_EXP[k_now];
 
 #if (not defined __clang__) && (defined __GNUG__)
 #pragma GCC unroll 4
@@ -125,7 +125,7 @@ intt(std::span<ml_dsa_field::zq_t, N> poly)
 
         poly[i] += poly[i + len];
         poly[i + len] = tmp - poly[i + len];
-        poly[i + len] *= neg_ζ_exp;
+        poly[i + len] *= neg_zeta_exp;
       }
     }
   }

--- a/include/ml_dsa/internals/poly/ntt.hpp
+++ b/include/ml_dsa/internals/poly/ntt.hpp
@@ -35,7 +35,7 @@ bit_rev(const size_t v)
   return v_rev;
 }
 
-// Precomputed table of powers of ?, used during polynomial evaluation.
+// Precomputed table of powers of zeta, used during polynomial evaluation.
 static constexpr auto zeta_EXP = []() {
   std::array<ml_dsa_field::zq_t, N> res;
 
@@ -46,7 +46,7 @@ static constexpr auto zeta_EXP = []() {
   return res;
 }();
 
-// Precomputed table of negated powers of ?, used during polynomial interpolation.
+// Precomputed table of negated powers of zeta, used during polynomial interpolation.
 static constexpr auto zeta_NEG_EXP = []() {
   std::array<ml_dsa_field::zq_t, N> res;
 

--- a/include/ml_dsa/internals/poly/sampling.hpp
+++ b/include/ml_dsa/internals/poly/sampling.hpp
@@ -74,7 +74,7 @@ static inline constexpr void
 expand_s(std::span<const uint8_t, 64> rho_prime, std::span<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> vec)
   requires(ml_dsa_params::check_eta(eta) && ml_dsa_params::check_nonce(nonce))
 {
-  constexpr auto eta = ml_dsa_field::zq_t(eta);
+  constexpr auto eta_value = ml_dsa_field::zq_t(eta);
 
   std::array<uint8_t, rho_prime.size() + 2> msg{};
   auto msg_span = std::span(msg);
@@ -103,27 +103,27 @@ expand_s(std::span<const uint8_t, 64> rho_prime, std::span<ml_dsa_field::zq_t, k
         const uint8_t t0 = buf_span[boff] & 0x0f;
         const uint8_t t1 = buf_span[boff] >> 4;
 
-        if constexpr (eta == 2u) {
+        if constexpr (eta_value == 2u) {
           const uint32_t t2 = static_cast<uint32_t>(t0 % 5);
           const bool flg0 = t0 < 15;
 
-          vec[off + n] = eta - ml_dsa_field::zq_t(t2);
+          vec[off + n] = eta_value - ml_dsa_field::zq_t(t2);
           n += flg0 * 1;
 
           const uint32_t t3 = static_cast<uint32_t>(t1 % 5);
           const bool flg1 = (t1 < 15) & (n < ml_dsa_ntt::N);
-          const ml_dsa_field::zq_t br[]{ vec[off], eta - ml_dsa_field::zq_t(t3) };
+          const ml_dsa_field::zq_t br[]{ vec[off], eta_value - ml_dsa_field::zq_t(t3) };
 
           vec[off + flg1 * n] = br[flg1];
           n += flg1 * 1;
         } else {
           const bool flg0 = t0 < 9;
 
-          vec[off + n] = eta - ml_dsa_field::zq_t(static_cast<uint32_t>(t0));
+          vec[off + n] = eta_value - ml_dsa_field::zq_t(static_cast<uint32_t>(t0));
           n += flg0 * 1;
 
           const bool flg1 = (t1 < 9) & (n < ml_dsa_ntt::N);
-          const auto t2 = eta - ml_dsa_field::zq_t(static_cast<uint32_t>(t1));
+          const auto t2 = eta_value - ml_dsa_field::zq_t(static_cast<uint32_t>(t1));
           const ml_dsa_field::zq_t br[]{ vec[off], t2 };
 
           vec[off + flg1 * n] = br[flg1];

--- a/include/ml_dsa/internals/poly/sampling.hpp
+++ b/include/ml_dsa/internals/poly/sampling.hpp
@@ -103,7 +103,7 @@ expand_s(std::span<const uint8_t, 64> rho_prime, std::span<ml_dsa_field::zq_t, k
         const uint8_t t0 = buf_span[boff] & 0x0f;
         const uint8_t t1 = buf_span[boff] >> 4;
 
-        if constexpr (eta_value == 2u) {
+        if constexpr (eta == 2u) {
           const uint32_t t2 = static_cast<uint32_t>(t0 % 5);
           const bool flg0 = t0 < 15;
 

--- a/include/ml_dsa/internals/utility/params.hpp
+++ b/include/ml_dsa/internals/utility/params.hpp
@@ -14,40 +14,40 @@ check_sbw(const size_t sbw)
   return sbw <= ml_dsa_field::Q_BIT_WIDTH;
 }
 
-// Compile-time check to ensure that η ∈ {2, 4}, so that sampled secret key range stays short i.e. [-η, η].
+// Compile-time check to ensure that eta ∈ {2, 4}, so that sampled secret key range stays short i.e. [-eta, eta].
 consteval bool
-check_η(const uint32_t η)
+check_eta(const uint32_t eta)
 {
-  return (η == 2u) || (η == 4u);
+  return (eta == 2u) || (eta == 4u);
 }
 
 // Compile-time check to ensure that starting nonce belongs to allowed set of values when uniform sampling polynomial
-// coefficients in [-η, η].
+// coefficients in [-eta, eta].
 consteval bool
 check_nonce(const size_t nonce)
 {
   return (nonce == 0) || (nonce == 4) || (nonce == 5) || (nonce == 7);
 }
 
-// Compile-time check to ensure that γ1 has recommended value.
+// Compile-time check to ensure that gamma1 has recommended value.
 consteval bool
-check_γ1(const uint32_t γ1)
+check_gamma1(const uint32_t gamma1)
 {
-  return (γ1 == (1u << 17)) || (γ1 == (1u << 19));
+  return (gamma1 == (1u << 17)) || (gamma1 == (1u << 19));
 }
 
-// Compile-time check to ensure that γ2 has recommended value.
+// Compile-time check to ensure that gamma2 has recommended value.
 consteval bool
-check_γ2(const uint32_t γ2)
+check_gamma2(const uint32_t gamma2)
 {
-  return (γ2 == ((ml_dsa_field::Q - 1) / 88)) || (γ2 == ((ml_dsa_field::Q - 1) / 32));
+  return (gamma2 == ((ml_dsa_field::Q - 1) / 88)) || (gamma2 == ((ml_dsa_field::Q - 1) / 32));
 }
 
-// Compile-time check to ensure that τ is set to parameter recommended in ML-DSA specification.
+// Compile-time check to ensure that tau is set to parameter recommended in ML-DSA specification.
 consteval bool
-check_τ(const uint32_t τ)
+check_tau(const uint32_t tau)
 {
-  return (τ == 39) || (τ == 49) || (τ == 60);
+  return (tau == 39) || (tau == 49) || (tau == 60);
 }
 
 // Compile-time check to ensure that number of bits to be dropped from a polynomial coefficient is supplied correctly.
@@ -67,11 +67,11 @@ check_matrix_dim(const size_t a_cols, const size_t b_rows)
 // Compile-time executable constraints for ensuring that ML-DSA key generation algorithm is only invoked with arguments
 // suggested in table 1 of ML-DSA standard https://doi.org/10.6028/NIST.FIPS.204.
 consteval bool
-check_keygen_params(const size_t k, const size_t l, const size_t d, const uint32_t η)
+check_keygen_params(const size_t k, const size_t l, const size_t d, const uint32_t eta)
 {
-  return ((k == 4) && (l == 4) && (d == 13) && (η == 2)) || // ML-DSA-44
-         ((k == 6) && (l == 5) && (d == 13) && (η == 4)) || // ML-DSA-65
-         ((k == 8) && (l == 7) && (d == 13) && (η == 2));   // ML-DSA-87
+  return ((k == 4) && (l == 4) && (d == 13) && (eta == 2)) || // ML-DSA-44
+         ((k == 6) && (l == 5) && (d == 13) && (eta == 4)) || // ML-DSA-65
+         ((k == 8) && (l == 7) && (d == 13) && (eta == 2));   // ML-DSA-87
 }
 
 // Compile-time executable constraints for ensuring that ML-DSA signing algorithm is only invoked with arguments
@@ -80,20 +80,20 @@ consteval bool
 check_signing_params(const size_t k,
                      const size_t l,
                      const size_t d,
-                     const uint32_t η,
-                     const uint32_t γ1,
-                     const uint32_t γ2,
-                     const uint32_t τ,
-                     const uint32_t β,
-                     const size_t ω,
-                     const size_t λ)
+                     const uint32_t eta,
+                     const uint32_t gamma1,
+                     const uint32_t gamma2,
+                     const uint32_t tau,
+                     const uint32_t beta,
+                     const size_t omega,
+                     const size_t lambda)
 {
-  return ((k == 4) && (l == 4) && (d == 13) && (η == 2) && (γ1 == (1u << 17)) && (γ2 == ((ml_dsa_field::Q - 1) / 88)) && (τ == 39) && (β == τ * η) && (ω == 80) &&
-          (λ == 128)) || // ML-DSA-44
-         ((k == 6) && (l == 5) && (d == 13) && (η == 4) && (γ1 == (1u << 19)) && (γ2 == ((ml_dsa_field::Q - 1) / 32)) && (τ == 49) && (β == τ * η) && (ω == 55) &&
-          (λ == 192)) || // ML-DSA-65
-         ((k == 8) && (l == 7) && (d == 13) && (η == 2) && (γ1 == (1u << 19)) && (γ2 == ((ml_dsa_field::Q - 1) / 32)) && (τ == 60) && (β == τ * η) && (ω == 75) &&
-          (λ == 256)); // ML-DSA-87
+  return ((k == 4) && (l == 4) && (d == 13) && (eta == 2) && (gamma1 == (1u << 17)) && (gamma2 == ((ml_dsa_field::Q - 1) / 88)) && (tau == 39) && (beta == tau * eta) && (omega == 80) &&
+          (lambda == 128)) || // ML-DSA-44
+         ((k == 6) && (l == 5) && (d == 13) && (eta == 4) && (gamma1 == (1u << 19)) && (gamma2 == ((ml_dsa_field::Q - 1) / 32)) && (tau == 49) && (beta == tau * eta) && (omega == 55) &&
+          (lambda == 192)) || // ML-DSA-65
+         ((k == 8) && (l == 7) && (d == 13) && (eta == 2) && (gamma1 == (1u << 19)) && (gamma2 == ((ml_dsa_field::Q - 1) / 32)) && (tau == 60) && (beta == tau * eta) && (omega == 75) &&
+          (lambda == 256)); // ML-DSA-87
 }
 
 // Compile-time executable constraints for ensuring that ML-DSA verification algorithm is only invoked with arguments
@@ -102,19 +102,19 @@ consteval bool
 check_verify_params(const size_t k,
                     const size_t l,
                     const size_t d,
-                    const uint32_t γ1,
-                    const uint32_t γ2,
-                    const uint32_t τ,
-                    const uint32_t β,
-                    const size_t ω,
-                    const size_t λ)
+                    const uint32_t gamma1,
+                    const uint32_t gamma2,
+                    const uint32_t tau,
+                    const uint32_t beta,
+                    const size_t omega,
+                    const size_t lambda)
 {
-  return ((k == 4) && (l == 4) && (d == 13) && (γ1 == (1u << 17)) && (γ2 == ((ml_dsa_field::Q - 1) / 88)) && (τ == 39) && (β == τ * 2) && (ω == 80) &&
-          (λ == 128)) || // ML-DSA-44
-         ((k == 6) && (l == 5) && (d == 13) && (γ1 == (1u << 19)) && (γ2 == ((ml_dsa_field::Q - 1) / 32)) && (τ == 49) && (β == τ * 4) && (ω == 55) &&
-          (λ == 192)) || // ML-DSA-65
-         ((k == 8) && (l == 7) && (d == 13) && (γ1 == (1u << 19)) && (γ2 == ((ml_dsa_field::Q - 1) / 32)) && (τ == 60) && (β == τ * 2) && (ω == 75) &&
-          (λ == 256)); // ML-DSA-87
+  return ((k == 4) && (l == 4) && (d == 13) && (gamma1 == (1u << 17)) && (gamma2 == ((ml_dsa_field::Q - 1) / 88)) && (tau == 39) && (beta == tau * 2) && (omega == 80) &&
+          (lambda == 128)) || // ML-DSA-44
+         ((k == 6) && (l == 5) && (d == 13) && (gamma1 == (1u << 19)) && (gamma2 == ((ml_dsa_field::Q - 1) / 32)) && (tau == 49) && (beta == tau * 4) && (omega == 55) &&
+          (lambda == 192)) || // ML-DSA-65
+         ((k == 8) && (l == 7) && (d == 13) && (gamma1 == (1u << 19)) && (gamma2 == ((ml_dsa_field::Q - 1) / 32)) && (tau == 60) && (beta == tau * 2) && (omega == 75) &&
+          (lambda == 256)); // ML-DSA-87
 }
 
 }

--- a/include/ml_dsa/internals/utility/utils.hpp
+++ b/include/ml_dsa/internals/utility/utils.hpp
@@ -19,9 +19,9 @@ pub_key_len(const size_t k, const size_t d)
 //
 // See table 1, 2 of ML-DSA standard https://doi.org/10.6028/NIST.FIPS.204.
 static inline constexpr size_t
-sec_key_len(const size_t k, const size_t l, const uint32_t η, const size_t d)
+sec_key_len(const size_t k, const size_t l, const uint32_t eta, const size_t d)
 {
-  const size_t eta_bw = std::bit_width(2 * η);
+  const size_t eta_bw = std::bit_width(2 * eta);
   const size_t sklen = 32 + 32 + 64 + 32 * (eta_bw * (k + l) + k * d);
   return sklen;
 }
@@ -30,10 +30,10 @@ sec_key_len(const size_t k, const size_t l, const uint32_t η, const size_t d)
 //
 // See table 1, 2 of ML-DSA standard https://doi.org/10.6028/NIST.FIPS.204.
 static inline constexpr size_t
-sig_len(const size_t k, const size_t l, const uint32_t γ1, const size_t ω, const size_t λ)
+sig_len(const size_t k, const size_t l, const uint32_t gamma1, const size_t omega, const size_t lambda)
 {
-  const size_t gamma1_bw = std::bit_width(γ1);
-  const size_t siglen = ((2 * λ) / std::numeric_limits<uint8_t>::digits) + (32 * l * gamma1_bw) + (ω + k);
+  const size_t gamma1_bw = std::bit_width(gamma1);
+  const size_t siglen = ((2 * lambda) / std::numeric_limits<uint8_t>::digits) + (32 * l * gamma1_bw) + (omega + k);
   return siglen;
 }
 

--- a/include/ml_dsa/ml_dsa_44.hpp
+++ b/include/ml_dsa/ml_dsa_44.hpp
@@ -5,15 +5,15 @@ namespace ml_dsa_44 {
 
 // See table 1 of ML-DSA standard @ https://doi.org/10.6028/NIST.FIPS.204
 static constexpr size_t d = 13;
-static constexpr uint32_t τ = 39;
-static constexpr uint32_t γ1 = 1u << 17;
-static constexpr uint32_t γ2 = (ml_dsa_field::Q - 1) / 88;
+static constexpr uint32_t tau = 39;
+static constexpr uint32_t gamma1 = 1u << 17;
+static constexpr uint32_t gamma2 = (ml_dsa_field::Q - 1) / 88;
 static constexpr size_t k = 4;
 static constexpr size_t l = 4;
-static constexpr uint32_t η = 2;
-static constexpr uint32_t β = τ * η;
-static constexpr size_t ω = 80;
-static constexpr size_t λ = 128;
+static constexpr uint32_t eta = 2;
+static constexpr uint32_t beta = tau * eta;
+static constexpr size_t omega = 80;
+static constexpr size_t lambda = 128;
 
 // Byte length ( = 32 ) of ML-DSA-44 key generation seed.
 static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
@@ -22,19 +22,19 @@ static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
 static constexpr size_t PubKeyByteLen = ml_dsa_utils::pub_key_len(k, d);
 
 // Byte length ( = 2560 ) of ML-DSA-44 secret key.
-static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, η, d);
+static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, eta, d);
 
 // Byte length ( = 32 ) of ML-DSA-44 signing seed.
 static constexpr size_t SigningSeedByteLen = ml_dsa::RND_BYTE_LEN;
 
 // Byte length ( = 2420 ) of ML-DSA-44 signature.
-static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, γ1, ω, λ);
+static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, gamma1, omega, lambda);
 
 // Given a 32 -bytes seed, this routine can be used for generating a fresh ML-DSA-44 keypair, in deterministic fashion.
 constexpr void
 keygen(std::span<const uint8_t, KeygenSeedByteLen> ξ, std::span<uint8_t, PubKeyByteLen> pubkey, std::span<uint8_t, SecKeyByteLen> seckey)
 {
-  ml_dsa::keygen<k, l, d, η>(ξ, pubkey, seckey);
+  ml_dsa::keygen<k, l, d, eta>(ξ, pubkey, seckey);
 }
 
 // Given a 32 -bytes seed `rnd` and ML-DSA-44 secret key, this routine can be used for signing any arbitrary (>=0)
@@ -50,7 +50,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
      std::span<const uint8_t> ctx,
      std::span<uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::sign<k, l, d, η, γ1, γ2, τ, β, ω, λ>(rnd, seckey, msg, ctx, sig);
+  return ml_dsa::sign<k, l, d, eta, gamma1, gamma2, tau, beta, omega, lambda>(rnd, seckey, msg, ctx, sig);
 }
 
 // Given a ML-DSA-44 public key, a message M, an optional context C (of length at max 255 -bytes) and a signature S,
@@ -59,7 +59,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
 constexpr bool
 verify(std::span<const uint8_t, PubKeyByteLen> pubkey, std::span<const uint8_t> msg, std::span<const uint8_t> ctx, std::span<const uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::verify<k, l, d, γ1, γ2, τ, β, ω, λ>(pubkey, msg, ctx, sig);
+  return ml_dsa::verify<k, l, d, gamma1, gamma2, tau, beta, omega, lambda>(pubkey, msg, ctx, sig);
 }
 
 }

--- a/include/ml_dsa/ml_dsa_65.hpp
+++ b/include/ml_dsa/ml_dsa_65.hpp
@@ -5,15 +5,15 @@ namespace ml_dsa_65 {
 
 // See table 1 of ML-DSA standard @ https://doi.org/10.6028/NIST.FIPS.204
 static constexpr size_t d = 13;
-static constexpr uint32_t τ = 49;
-static constexpr uint32_t γ1 = 1u << 19;
-static constexpr uint32_t γ2 = (ml_dsa_field::Q - 1) / 32;
+static constexpr uint32_t tau = 49;
+static constexpr uint32_t gamma1 = 1u << 19;
+static constexpr uint32_t gamma2 = (ml_dsa_field::Q - 1) / 32;
 static constexpr size_t k = 6;
 static constexpr size_t l = 5;
-static constexpr uint32_t η = 4;
-static constexpr uint32_t β = τ * η;
-static constexpr size_t ω = 55;
-static constexpr size_t λ = 192;
+static constexpr uint32_t eta = 4;
+static constexpr uint32_t beta = tau * eta;
+static constexpr size_t omega = 55;
+static constexpr size_t lambda = 192;
 
 // Byte length ( = 32 ) of ML-DSA-65 key generation seed.
 static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
@@ -22,19 +22,19 @@ static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
 static constexpr size_t PubKeyByteLen = ml_dsa_utils::pub_key_len(k, d);
 
 // Byte length ( = 4032 ) of ML-DSA-65 secret key.
-static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, η, d);
+static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, eta, d);
 
 // Byte length ( = 32 ) of ML-DSA-65 signing seed.
 static constexpr size_t SigningSeedByteLen = ml_dsa::RND_BYTE_LEN;
 
 // Byte length ( = 3309 ) of ML-DSA-65 signature.
-static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, γ1, ω, λ);
+static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, gamma1, omega, lambda);
 
 // Given a 32 -bytes seed, this routine can be used for generating a fresh ML-DSA-65 keypair, in deterministic fashion.
 constexpr void
 keygen(std::span<const uint8_t, KeygenSeedByteLen> ξ, std::span<uint8_t, PubKeyByteLen> pubkey, std::span<uint8_t, SecKeyByteLen> seckey)
 {
-  ml_dsa::keygen<k, l, d, η>(ξ, pubkey, seckey);
+  ml_dsa::keygen<k, l, d, eta>(ξ, pubkey, seckey);
 }
 
 // Given a 32 -bytes seed `rnd` and ML-DSA-65 secret key, this routine can be used for signing any arbitrary (>=0)
@@ -51,7 +51,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
 
      std::span<uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::sign<k, l, d, η, γ1, γ2, τ, β, ω, λ>(rnd, seckey, msg, ctx, sig);
+  return ml_dsa::sign<k, l, d, eta, gamma1, gamma2, tau, beta, omega, lambda>(rnd, seckey, msg, ctx, sig);
 }
 
 // Given a ML-DSA-65 public key, a message M, an optional context C (of length at max 255 -bytes) and a signature S,
@@ -60,7 +60,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
 constexpr bool
 verify(std::span<const uint8_t, PubKeyByteLen> pubkey, std::span<const uint8_t> msg, std::span<const uint8_t> ctx, std::span<const uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::verify<k, l, d, γ1, γ2, τ, β, ω, λ>(pubkey, msg, ctx, sig);
+  return ml_dsa::verify<k, l, d, gamma1, gamma2, tau, beta, omega, lambda>(pubkey, msg, ctx, sig);
 }
 
 }

--- a/include/ml_dsa/ml_dsa_87.hpp
+++ b/include/ml_dsa/ml_dsa_87.hpp
@@ -5,15 +5,15 @@ namespace ml_dsa_87 {
 
 // See table 1 of ML-DSA standard @ https://doi.org/10.6028/NIST.FIPS.204
 static constexpr size_t d = 13;
-static constexpr uint32_t τ = 60;
-static constexpr uint32_t γ1 = 1u << 19;
-static constexpr uint32_t γ2 = (ml_dsa_field::Q - 1) / 32;
+static constexpr uint32_t tau = 60;
+static constexpr uint32_t gamma1 = 1u << 19;
+static constexpr uint32_t gamma2 = (ml_dsa_field::Q - 1) / 32;
 static constexpr size_t k = 8;
 static constexpr size_t l = 7;
-static constexpr uint32_t η = 2;
-static constexpr uint32_t β = τ * η;
-static constexpr size_t ω = 75;
-static constexpr size_t λ = 256;
+static constexpr uint32_t eta = 2;
+static constexpr uint32_t beta = tau * eta;
+static constexpr size_t omega = 75;
+static constexpr size_t lambda = 256;
 
 // Byte length ( = 32 ) of ML-DSA-87 key generation seed.
 static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
@@ -22,19 +22,19 @@ static constexpr size_t KeygenSeedByteLen = ml_dsa::KEYGEN_SEED_BYTE_LEN;
 static constexpr size_t PubKeyByteLen = ml_dsa_utils::pub_key_len(k, d);
 
 // Byte length ( = 4896 ) of ML-DSA-87 secret key.
-static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, η, d);
+static constexpr size_t SecKeyByteLen = ml_dsa_utils::sec_key_len(k, l, eta, d);
 
 // Byte length ( = 32 ) of ML-DSA-87 signing seed.
 static constexpr size_t SigningSeedByteLen = ml_dsa::RND_BYTE_LEN;
 
 // Byte length ( = 4627 ) of ML-DSA-87 signature.
-static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, γ1, ω, λ);
+static constexpr size_t SigByteLen = ml_dsa_utils::sig_len(k, l, gamma1, omega, lambda);
 
 // Given a 32 -bytes seed, this routine can be used for generating a fresh ML-DSA-87 keypair, in deterministic fashion.
 constexpr void
 keygen(std::span<const uint8_t, KeygenSeedByteLen> ξ, std::span<uint8_t, PubKeyByteLen> pubkey, std::span<uint8_t, SecKeyByteLen> seckey)
 {
-  ml_dsa::keygen<k, l, d, η>(ξ, pubkey, seckey);
+  ml_dsa::keygen<k, l, d, eta>(ξ, pubkey, seckey);
 }
 
 // Given a 32 -bytes seed `rnd` and ML-DSA-87 secret key, this routine can be used for signing any arbitrary (>=0)
@@ -50,7 +50,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
      std::span<const uint8_t> ctx,
      std::span<uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::sign<k, l, d, η, γ1, γ2, τ, β, ω, λ>(rnd, seckey, msg, ctx, sig);
+  return ml_dsa::sign<k, l, d, eta, gamma1, gamma2, tau, beta, omega, lambda>(rnd, seckey, msg, ctx, sig);
 }
 
 // Given a ML-DSA-87 public key, a message M, an optional context C (of length at max 255 -bytes) and a signature S,
@@ -59,7 +59,7 @@ sign(std::span<const uint8_t, SigningSeedByteLen> rnd,
 constexpr bool
 verify(std::span<const uint8_t, PubKeyByteLen> pubkey, std::span<const uint8_t> msg, std::span<const uint8_t> ctx, std::span<const uint8_t, SigByteLen> sig)
 {
-  return ml_dsa::verify<k, l, d, γ1, γ2, τ, β, ω, λ>(pubkey, msg, ctx, sig);
+  return ml_dsa::verify<k, l, d, gamma1, gamma2, tau, beta, omega, lambda>(pubkey, msg, ctx, sig);
 }
 
 }

--- a/tests/test_bit_packing.cpp
+++ b/tests/test_bit_packing.cpp
@@ -67,8 +67,8 @@ TEST(ML_DSA, PolynomialEncodingDecodingWithSignificantBitWidth20)
   test_encode_decode_of_polynomials<20>();
 }
 
-// Generates random hint bit polynomial vector of dimension k x 1, with <= ω coefficients set to 1.
-template<size_t k, size_t ω>
+// Generates random hint bit polynomial vector of dimension k x 1, with <= omega coefficients set to 1.
+template<size_t k, size_t omega>
 static void
 generate_random_hint_bits(std::span<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> poly)
 {
@@ -81,18 +81,18 @@ generate_random_hint_bits(std::span<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> poly)
   std::mt19937_64 gen(rd());
   std::uniform_int_distribution<size_t> dis{ frm, to };
 
-  for (size_t i = 0; i < ω; i++) {
+  for (size_t i = 0; i < omega; i++) {
     const size_t idx = dis(gen);
     poly[idx] = ml_dsa_field::zq_t::one();
   }
 }
 
 // Test functional correctness of encoding and decoding of hint bit polynomial vector.
-template<size_t k, size_t ω>
+template<size_t k, size_t omega>
 static void
 test_encode_decode_of_hint_polynomial()
 {
-  constexpr size_t hint_byte_len = ω + k;
+  constexpr size_t hint_byte_len = omega + k;
 
   std::array<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h0{};
   std::array<ml_dsa_field::zq_t, k * ml_dsa_ntt::N> h1{};
@@ -101,18 +101,18 @@ test_encode_decode_of_hint_polynomial()
   std::array<uint8_t, hint_byte_len> hint_poly_bytes0{};
   std::array<uint8_t, hint_byte_len> hint_poly_bytes1{};
 
-  generate_random_hint_bits<k, ω>(h0);
+  generate_random_hint_bits<k, omega>(h0);
 
-  ml_dsa_bit_packing::encode_hint_bits<k, ω>(h0, hint_poly_bytes0);
+  ml_dsa_bit_packing::encode_hint_bits<k, omega>(h0, hint_poly_bytes0);
 
   std::copy(hint_poly_bytes0.begin(), hint_poly_bytes0.end(), hint_poly_bytes1.begin());
   hint_poly_bytes1[hint_byte_len - 1] = ~hint_poly_bytes1[hint_byte_len - 1];
 
-  const bool failed0 = ml_dsa_bit_packing::decode_hint_bits<k, ω>(hint_poly_bytes0, h1);
+  const bool failed0 = ml_dsa_bit_packing::decode_hint_bits<k, omega>(hint_poly_bytes0, h1);
   EXPECT_FALSE(failed0);
   EXPECT_TRUE(std::equal(h0.begin(), h0.end(), h1.begin()));
 
-  const bool failed1 = ml_dsa_bit_packing::decode_hint_bits<k, ω>(hint_poly_bytes1, h2);
+  const bool failed1 = ml_dsa_bit_packing::decode_hint_bits<k, omega>(hint_poly_bytes1, h2);
   EXPECT_TRUE(failed1);
   EXPECT_FALSE(std::equal(h0.begin(), h0.end(), h2.begin()));
 }

--- a/tests/test_sampling.cpp
+++ b/tests/test_sampling.cpp
@@ -5,20 +5,20 @@
 #include <numeric>
 
 // Check whether hashing to a ball routine works as expected or not.
-template<uint32_t τ, size_t λ>
+template<uint32_t tau, size_t lambda>
 static void
 test_sample_in_ball()
 {
-  std::array<uint8_t, (2 * λ) / std::numeric_limits<uint8_t>::digits> seed{};
+  std::array<uint8_t, (2 * lambda) / std::numeric_limits<uint8_t>::digits> seed{};
   std::array<ml_dsa_field::zq_t, ml_dsa_ntt::N> poly{};
 
   randomshake::randomshake_t<256> csprng;
   csprng.generate(seed);
 
-  ml_dsa_sampling::sample_in_ball<τ, λ>(seed, poly);
+  ml_dsa_sampling::sample_in_ball<tau, lambda>(seed, poly);
 
   auto sqrd_norm = std::accumulate(poly.begin(), poly.end(), ml_dsa_field::zq_t::zero(), [](auto acc, auto cur) -> auto { return acc + (cur * cur); });
-  EXPECT_EQ(sqrd_norm, ml_dsa_field::zq_t(τ));
+  EXPECT_EQ(sqrd_norm, ml_dsa_field::zq_t(tau));
 }
 
 TEST(ML_DSA, SampleInBallFor_ML_DSA_44)


### PR DESCRIPTION
Compiling the current code  using `MSVC 2022` throws a lot of `C3872` compiler errors such as: 
`error C3872: '0x2030': this character is not allowed in an identifier` for the `ω` symbol for example.

This is due to the fact that the `MSVC` compiler `follows the C++11 standard on characters allowed in an identifier` : see [Microsoft documentation](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3872?view=msvc-170) 

The issue is resolved by replacing the Greek alphabet symbols with their corresponding English names.